### PR TITLE
Add missing <functional> header

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,6 @@
 #include <cstdint>
 #include <fstream>
+#include <functional>
 #include <iostream>
 #include <memory>
 #include <queue>


### PR DESCRIPTION
Add missing `<functional>` header. Thanks to @Nicholas-Baron for pointing this out. Apparently I have an older version of GCC which includes this automatically.

This PR fixes https://github.com/stepchowfun/cfg-checker/issues/1.